### PR TITLE
feat: add about section with portfolio

### DIFF
--- a/frontend/src/components/About.tsx
+++ b/frontend/src/components/About.tsx
@@ -22,7 +22,7 @@ const About: React.FC = () => {
           onViewportEnter={() => setStartTyping(true)}
           viewport={{ once: true }}
           transition={{ duration: 1.5 }}
-          className="mb-10 text-center"
+          className="mb-10 text-left"
         >
           <h2 className="relative inline-block text-4xl font-bold text-gray-50">
             {typedText}
@@ -34,34 +34,17 @@ const About: React.FC = () => {
         <div className="grid gap-8 md:grid-cols-2">
           <GlassCard className="p-6 text-gray-200 space-y-4">
             <p>
-              Hey! I'm a CS major at
-              <a
-                href="https://www.utdallas.edu"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-primary hover:underline"
-              >
-                UT Dallas
-              </a>
-              who loves blending applied machine learning with full-stack
-              tinkering. These days I'm either building routing models that mix
-              reinforcement learning with classic algorithms or exploring how
-              brains react to real-world stimuli.
+              Hey! I'm a CS major at UT Dallas who loves blending applied
+              machine learning with full-stack tinkering. These days I'm either
+              building routing models that mix reinforcement learning with
+              classic algorithms or exploring how brains react to real-world
+              stimuli.
             </p>
             <p>
-              Last summer I hopped on
-              <a
-                href="https://www.abilitie.com/ai-cases"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-primary hover:underline"
-              >
-                Abilitie's
-              </a>
-              team to ship an LLM-powered training product. I benchmarked
-              deployment tricks to shrink inference bills, spun up telemetry
-              pipelines in TypeScript and DynamoDB, and tweaked both fine-tuning
-              and frontend UX.
+              Last summer I hopped on Abilitie's team to ship an LLM-powered
+              training product. I benchmarked deployment tricks to shrink
+              inference bills, spun up telemetry pipelines in TypeScript and
+              DynamoDB, and tweaked both fine-tuning and frontend UX.
             </p>
             <p>
               I'm on the lookout for a Summer 2025 internship in ML, data, or
@@ -70,17 +53,17 @@ const About: React.FC = () => {
               SQL.
             </p>
             <p>
-              Away from the keyboard, you'll catch me behind a camera—my dining
-              hall documentary was screened at the
+              Away from the keyboard, you'll catch me behind a camera. My dining
+              hall documentary was screened at the 
               <a
                 href="https://www.hsfilmfest.com/2023-official-selections"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-primary hover:underline"
+                className="text-gray-200 hover:underline hover:text-[#D44638]"
               >
                 All American High School Film Festival
               </a>
-              —or chasing tennis rallies and La Liga scores (Visca Barça!). I
+              , or chasing tennis rallies and La Liga scores (Visca Barça!). I
               love experimenting in the kitchen, traveling (I've lived in three
               countries and visited ten-plus), hitting the gym, and keeping up
               with Formula 1.
@@ -89,14 +72,7 @@ const About: React.FC = () => {
 
           <div className="space-y-6">
             <GlassCard className="p-4 text-center text-gray-200">
-              <a
-                href="https://www.hsfilmfest.com/2023-official-selections"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="hover:underline"
-              >
-                Check out my film work
-              </a>
+              Check out my film work!
             </GlassCard>
             <GlassCard className="overflow-hidden">
               <div className="aspect-video">

--- a/frontend/src/components/About.tsx
+++ b/frontend/src/components/About.tsx
@@ -1,0 +1,158 @@
+import React, { useState } from "react";
+import { motion } from "framer-motion";
+import { useTypewriter, Cursor } from "react-simple-typewriter";
+import GlassCard from "./ui/GlassCard";
+
+const About: React.FC = () => {
+  const [startTyping, setStartTyping] = useState(false);
+  const [typedText] = useTypewriter({
+    words: startTyping ? ["About Me"] : [""],
+    loop: false,
+    typeSpeed: 120,
+    deleteSpeed: 60,
+    delaySpeed: 1000,
+  });
+
+  return (
+    <section className="py-16">
+      <div className="container mx-auto max-w-screen-xl px-4 md:px-16">
+        <motion.div
+          initial={{ opacity: 0 }}
+          whileInView={{ opacity: 1 }}
+          onViewportEnter={() => setStartTyping(true)}
+          viewport={{ once: true }}
+          transition={{ duration: 1.5 }}
+          className="mb-10 text-center"
+        >
+          <h2 className="relative inline-block text-4xl font-bold text-gray-50">
+            {typedText}
+            <Cursor />
+            <span className="block w-16 h-1 bg-primary mx-auto mt-2 rounded"></span>
+          </h2>
+        </motion.div>
+
+        <div className="grid gap-8 md:grid-cols-2">
+          <GlassCard className="p-6 text-gray-200 space-y-4">
+            <p>
+              Computer Science student at UT Dallas focused on applied machine
+              learning and full-stack development. I explore hybrid optimization
+              combining reinforcement learning with classical algorithms and
+              model neural responses to real-world stimuli.
+            </p>
+            <p>
+              Previously helped launch an LLM-powered training product at
+              Abilitie—benchmarking deployment strategies to cut inference cost,
+              building telemetry pipelines in TypeScript and DynamoDB, and
+              polishing both fine-tuning and frontend UX.
+            </p>
+            <p>
+              Actively seeking Summer 2025 internships in machine learning, data
+              science, AI research, or full-stack development. Stack: Python,
+              TypeScript, React, Flask, Node.js, AWS (SageMaker, Bedrock, EC2),
+              PyTorch, TensorFlow, SQL.
+            </p>
+            <ul className="list-disc list-inside space-y-1">
+              <li>
+                Filmmaking – All American High School Film Festival nominee
+              </li>
+              <li>Tennis & soccer fan (Visca Barça!)</li>
+              <li>Foodie and home cook chasing new cuisines</li>
+              <li>Traveller – lived in 3 countries, visited 10+</li>
+              <li>Gym rat and Formula 1 enthusiast</li>
+            </ul>
+          </GlassCard>
+
+          <div className="space-y-6">
+            <GlassCard className="overflow-hidden">
+              <div className="aspect-video">
+                <iframe
+                  className="w-full h-full"
+                  src="https://www.youtube.com/embed/WM6RvRfDCX4"
+                  title="St. Stephen’s Dining Hall Documentary"
+                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                  allowFullScreen
+                ></iframe>
+              </div>
+              <p className="text-sm text-gray-200 mt-2 text-center">
+                2022 – St. Stephen’s Dining Hall Documentary
+              </p>
+            </GlassCard>
+
+            <GlassCard className="overflow-hidden">
+              <div className="aspect-video">
+                <iframe
+                  className="w-full h-full"
+                  src="https://www.youtube.com/embed/FS8l8G2p7PM"
+                  title="The PB&J Documentary"
+                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                  allowFullScreen
+                ></iframe>
+              </div>
+              <p className="text-sm text-gray-200 mt-2 text-center">
+                2023 – The PB&J Documentary
+              </p>
+            </GlassCard>
+
+            <GlassCard className="p-4 text-center">
+              <h4 className="text-lg font-semibold text-gray-50 mb-2">
+                Photography Samples
+              </h4>
+              <div className="flex flex-wrap justify-center gap-4 text-sm">
+                <a
+                  href="https://drive.google.com/file/d/1C_NE9LsEFUwXJ8DoewZUHVWl14dthKvd/view?usp=sharing"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary hover:underline"
+                >
+                  Photo 1
+                </a>
+                <a
+                  href="https://drive.google.com/file/d/1qV96I87FDxwIqZnv5R8s7e09OOZEUs8o/view?usp=sharing"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary hover:underline"
+                >
+                  Photo 2
+                </a>
+                <a
+                  href="https://drive.google.com/file/d/1whFFNbwniIFgU1cQEcsD5PurugvdAIG4/view?usp=sharing"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary hover:underline"
+                >
+                  Photo 3
+                </a>
+                <a
+                  href="https://drive.google.com/file/d/1Jj5exsNTSntwkotpzE4tNWB-6x-TqKjC/view?usp=sharing"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary hover:underline"
+                >
+                  Photo 4
+                </a>
+                <a
+                  href="https://drive.google.com/file/d/16fi_GhyFVqD53qk8FON6OtSyE_w8TBBp/view?usp=sharing"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary hover:underline"
+                >
+                  Photo 5
+                </a>
+                <a
+                  href="https://drive.google.com/file/d/1zk4s_n8wQzZCcqwrilFXzv1yzMzB4jDJ/view?usp=sharing"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary hover:underline"
+                >
+                  Photo 6
+                </a>
+              </div>
+            </GlassCard>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default About;

--- a/frontend/src/components/About.tsx
+++ b/frontend/src/components/About.tsx
@@ -34,17 +34,34 @@ const About: React.FC = () => {
         <div className="grid gap-8 md:grid-cols-2">
           <GlassCard className="p-6 text-gray-200 space-y-4">
             <p>
-              Hey! I'm a CS major at UT Dallas who loves blending applied
-              machine learning with full-stack tinkering. These days I'm either
-              building routing models that mix reinforcement learning with
-              classic algorithms or exploring how brains react to real-world
-              stimuli.
+              Hey! I'm a CS major at
+              <a
+                href="https://www.utdallas.edu"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary hover:underline"
+              >
+                UT Dallas
+              </a>
+              who loves blending applied machine learning with full-stack
+              tinkering. These days I'm either building routing models that mix
+              reinforcement learning with classic algorithms or exploring how
+              brains react to real-world stimuli.
             </p>
             <p>
-              Last summer I hopped on Abilitie's team to ship an
-              LLM-powered training product. I benchmarked deployment tricks to
-              shrink inference bills, spun up telemetry pipelines in TypeScript
-              and DynamoDB, and tweaked both fine-tuning and frontend UX.
+              Last summer I hopped on
+              <a
+                href="https://www.abilitie.com/ai-cases"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary hover:underline"
+              >
+                Abilitie's
+              </a>
+              team to ship an LLM-powered training product. I benchmarked
+              deployment tricks to shrink inference bills, spun up telemetry
+              pipelines in TypeScript and DynamoDB, and tweaked both fine-tuning
+              and frontend UX.
             </p>
             <p>
               I'm on the lookout for a Summer 2025 internship in ML, data, or
@@ -52,16 +69,35 @@ const About: React.FC = () => {
               around with React, Flask, Node.js, AWS, PyTorch, TensorFlow, and
               SQL.
             </p>
-            <ul className="list-disc list-inside space-y-1">
-              <li>Filmmaker with an All American High School Film Festival nod</li>
-              <li>Tennis & soccer junkie (Visca Barça!)</li>
-              <li>Food lover and experimental home cook</li>
-              <li>Traveller – lived in 3 countries, visited 10+</li>
-              <li>Gym regular and Formula 1 follower</li>
-            </ul>
+            <p>
+              Away from the keyboard, you'll catch me behind a camera—my dining
+              hall documentary was screened at the
+              <a
+                href="https://www.hsfilmfest.com/2023-official-selections"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary hover:underline"
+              >
+                All American High School Film Festival
+              </a>
+              —or chasing tennis rallies and La Liga scores (Visca Barça!). I
+              love experimenting in the kitchen, traveling (I've lived in three
+              countries and visited ten-plus), hitting the gym, and keeping up
+              with Formula 1.
+            </p>
           </GlassCard>
 
           <div className="space-y-6">
+            <GlassCard className="p-4 text-center text-gray-200">
+              <a
+                href="https://www.hsfilmfest.com/2023-official-selections"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="hover:underline"
+              >
+                Check out my film work
+              </a>
+            </GlassCard>
             <GlassCard className="overflow-hidden">
               <div className="aspect-video">
                 <iframe

--- a/frontend/src/components/About.tsx
+++ b/frontend/src/components/About.tsx
@@ -34,31 +34,30 @@ const About: React.FC = () => {
         <div className="grid gap-8 md:grid-cols-2">
           <GlassCard className="p-6 text-gray-200 space-y-4">
             <p>
-              Computer Science student at UT Dallas focused on applied machine
-              learning and full-stack development. I explore hybrid optimization
-              combining reinforcement learning with classical algorithms and
-              model neural responses to real-world stimuli.
+              Hey! I'm a CS major at UT Dallas who loves blending applied
+              machine learning with full-stack tinkering. These days I'm either
+              building routing models that mix reinforcement learning with
+              classic algorithms or exploring how brains react to real-world
+              stimuli.
             </p>
             <p>
-              Previously helped launch an LLM-powered training product at
-              Abilitie—benchmarking deployment strategies to cut inference cost,
-              building telemetry pipelines in TypeScript and DynamoDB, and
-              polishing both fine-tuning and frontend UX.
+              Last summer I hopped on Abilitie's team to ship an
+              LLM-powered training product. I benchmarked deployment tricks to
+              shrink inference bills, spun up telemetry pipelines in TypeScript
+              and DynamoDB, and tweaked both fine-tuning and frontend UX.
             </p>
             <p>
-              Actively seeking Summer 2025 internships in machine learning, data
-              science, AI research, or full-stack development. Stack: Python,
-              TypeScript, React, Flask, Node.js, AWS (SageMaker, Bedrock, EC2),
-              PyTorch, TensorFlow, SQL.
+              I'm on the lookout for a Summer 2025 internship in ML, data, or
+              full-stack work. I mostly code in Python and TypeScript and mess
+              around with React, Flask, Node.js, AWS, PyTorch, TensorFlow, and
+              SQL.
             </p>
             <ul className="list-disc list-inside space-y-1">
-              <li>
-                Filmmaking – All American High School Film Festival nominee
-              </li>
-              <li>Tennis & soccer fan (Visca Barça!)</li>
-              <li>Foodie and home cook chasing new cuisines</li>
+              <li>Filmmaker with an All American High School Film Festival nod</li>
+              <li>Tennis & soccer junkie (Visca Barça!)</li>
+              <li>Food lover and experimental home cook</li>
               <li>Traveller – lived in 3 countries, visited 10+</li>
-              <li>Gym rat and Formula 1 enthusiast</li>
+              <li>Gym regular and Formula 1 follower</li>
             </ul>
           </GlassCard>
 
@@ -91,62 +90,6 @@ const About: React.FC = () => {
               <p className="text-sm text-gray-200 mt-2 text-center">
                 2023 – The PB&J Documentary
               </p>
-            </GlassCard>
-
-            <GlassCard className="p-4 text-center">
-              <h4 className="text-lg font-semibold text-gray-50 mb-2">
-                Photography Samples
-              </h4>
-              <div className="flex flex-wrap justify-center gap-4 text-sm">
-                <a
-                  href="https://drive.google.com/file/d/1C_NE9LsEFUwXJ8DoewZUHVWl14dthKvd/view?usp=sharing"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-primary hover:underline"
-                >
-                  Photo 1
-                </a>
-                <a
-                  href="https://drive.google.com/file/d/1qV96I87FDxwIqZnv5R8s7e09OOZEUs8o/view?usp=sharing"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-primary hover:underline"
-                >
-                  Photo 2
-                </a>
-                <a
-                  href="https://drive.google.com/file/d/1whFFNbwniIFgU1cQEcsD5PurugvdAIG4/view?usp=sharing"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-primary hover:underline"
-                >
-                  Photo 3
-                </a>
-                <a
-                  href="https://drive.google.com/file/d/1Jj5exsNTSntwkotpzE4tNWB-6x-TqKjC/view?usp=sharing"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-primary hover:underline"
-                >
-                  Photo 4
-                </a>
-                <a
-                  href="https://drive.google.com/file/d/16fi_GhyFVqD53qk8FON6OtSyE_w8TBBp/view?usp=sharing"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-primary hover:underline"
-                >
-                  Photo 5
-                </a>
-                <a
-                  href="https://drive.google.com/file/d/1zk4s_n8wQzZCcqwrilFXzv1yzMzB4jDJ/view?usp=sharing"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-primary hover:underline"
-                >
-                  Photo 6
-                </a>
-              </div>
             </GlassCard>
           </div>
         </div>

--- a/frontend/src/components/SectionSidebar.tsx
+++ b/frontend/src/components/SectionSidebar.tsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect, useRef } from "react";
 
 const sections = [
   { id: "intro", label: "Home" },
+  { id: "about", label: "About" },
   { id: "education", label: "Education" },
   { id: "experiences", label: "Experiences" },
   { id: "projects", label: "Projects" },
@@ -29,7 +30,10 @@ const SectionSidebar: React.FC = () => {
         const element = document.getElementById(section.id);
         if (element) {
           const rect = element.getBoundingClientRect();
-          if (rect.top <= window.innerHeight / 2 && rect.bottom >= window.innerHeight / 2) {
+          if (
+            rect.top <= window.innerHeight / 2 &&
+            rect.bottom >= window.innerHeight / 2
+          ) {
             current = section.id;
           }
         }

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,16 +1,19 @@
 // src/pages/Home.tsx
 import React from "react";
 import Intro from "../components/Intro";
+import About from "../components/About";
 import Education from "../components/Education";
 import Experiences from "../components/Experience";
 import Projects from "../components/Projects";
-
 
 const Home: React.FC = () => {
   return (
     <div>
       <section id="intro">
         <Intro />
+      </section>
+      <section id="about">
+        <About />
       </section>
       <section id="education">
         <Education />


### PR DESCRIPTION
## Summary
- add responsive About section with bio, interests, and film/photography portfolio
- embed dining hall and PB&J documentaries as video cards
- wire About section into home page and sidebar navigation

## Testing
- `npm run lint` *(fails: Unexpected any in WeatherCard.tsx)*
- `npm run build`
- `cd backend && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68958072f5c48331b26020fa9aed7570